### PR TITLE
fix: only log when nagios.com is unreachable

### DIFF
--- a/nagios_exporter.go
+++ b/nagios_exporter.go
@@ -472,9 +472,9 @@ func (e *Exporter) QueryAPIsAndUpdateMetrics(ch chan<- prometheus.Metric, sslVer
 				updateAvailable, prometheus.GaugeValue, updateMetric,
 				// updateMetric 0 = no update, updateMetric 1 = update available
 			)
+		} else {
+			log.Warn("Nagios version wasn't found, not updating `nagios_update_available_info` metric")
 		}
-
-		log.Warn("Nagios version wasn't found, not updating `nagios_update_available_info` metric")
 
 	} else { // user did not want to compare nagios versions externally so just say there aren't any updates (0)
 		ch <- prometheus.MustNewConstMetric(


### PR DESCRIPTION
Fixes #53 

I was silly and should've done an else here in #51, otherwise this will constantly log that it couldn't reach *.nagios.com regardless of if it can or not.